### PR TITLE
[power_shell] add ability to recompile a module exporting extra functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 # Changelog
 Every release has a corresponding tag. Use `master` branch for fresh-from-the-oven code.
 
+## 1.2
+  - Added support for hot-code loaded exports
+
 ## 1.1.7
   - Dropped support for OTP 20, added support for future OTP 25 release
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # power_shell
 
-Advanced system-wide Erlang shell capabilities
+Advanced system-wide Erlang shell capabilities. Evaluates Erlang code loaded from the module debug
+information, or source file.
 
 Build with rebar3:
 
     rebar3 compile
 
-Versions supported: tested with OTP 20, 21, 22, 23 and 24.
-There is no support for older OTP versions, due to changes made for R20. 
-Basic eval() worked down to R16B.
+Versions supported: tested with 21, 22, 23 and 24.
 
 Documentation can be built with edoc: `rebar3 edoc`
 
@@ -45,6 +44,19 @@ this behaviour, set `skip_on_load` application variable to `false`:
 
     ok = application:load(power_shell),
     ok = application:set_env(power_shell, skip_on_load, false).
+
+### Recompiling and hot-loading modules with extra functions exported
+Starting with version 1.2, power_shell can recompile an existing module exporting all or selected functions. Use
+`power_shell:export(Mod)` to export all functions. This may be used in conjunction with Common Test suites,
+allowing for white-box testing of functions that should not be exported in production code. Example:
+
+    my_case(Config) when is_list(Config) ->
+        Old = power_shell:export(prod_module),
+        WhiteBoxRet = prod_module:not_exported_fun(123),
+        power_shell:revert(Old).
+
+For reliable Common Test execution `export/1,2,3` start a linked process that will reload the original code
+upon termination. This allows to avoid failing other test cases that do not expect extra exports available.
 
 ## Configuration
 During application startup, power_shell examines following application environment variables:

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -2,7 +2,7 @@
 
    @author Maxim Fedorov
    @copyright Copyright (c) WhatsApp Inc. and its affiliates. All rights reserved.
-   @version 1.1.7
+   @version 1.2
    @title power_shell: advanced system-wide Erlang shell capabilities
    @doc power_shell can be used as an application, and in form of a library. When started as application, power_shell examines
         <strong>shell_integration</strong> configuration parameter. It can be set to shell_default, or user_default. Depending on the
@@ -32,6 +32,19 @@
 
             ``ok = application:load(power_shell),
             ok = application:set_env(power_shell, skip_on_load, false).''
+
+        === Recompiling and hot-loading modules with extra functions exported ===
+        Starting with version 1.2, power_shell can recompile an existing module exporting all or selected functions. Use
+        `power_shell:export(Mod)' to export all functions. This may be used in conjunction with Common Test suites,
+        allowing for white-box testing of functions that should not be exported in production code. Example:
+
+            ``my_case(Config) when is_list(Config) ->
+                Old = power_shell:export(prod_module),
+                WhiteBoxRet = prod_module:not_exported_fun(123),
+                power_shell:revert(Old).''
+
+        For reliable Common Test execution `export/1,2,3' start a linked process that will reload the original code
+        upon termination. This allows to avoid failing other test cases that do not expect extra exports available.
 
         == Configuration ==
 

--- a/src/power_shell.app.src
+++ b/src/power_shell.app.src
@@ -1,6 +1,6 @@
 {application, power_shell,
  [{description, "Erlang shell extension allowing to evaluate non-exported functions"},
-  {vsn, "1.1.7"},
+  {vsn, "1.2"},
   {registered, [power_shell_cache]},
   {mod, {power_shell_app, []}},
   {applications,

--- a/test/power_shell_cache_SUITE.erl
+++ b/test/power_shell_cache_SUITE.erl
@@ -41,7 +41,7 @@
 -define(VICTIM, power_shell_SUITE).
 
 suite() ->
-    [{timetrap,{seconds,30}}].
+    [{timetrap, {seconds, 30}}].
 
 all() ->
     [get_module, bad_calls, start_stop, cache_md5_check, not_loaded, cover_compiled_direct,

--- a/test/power_shell_export.erl
+++ b/test/power_shell_export.erl
@@ -1,0 +1,27 @@
+%%%-------------------------------------------------------------------
+%%% @author Maxim Fedorov <maximfca@gmail.com>
+%%% @copyright (c) WhatsApp Inc. and its affiliates. All rights reserved.
+%%% @doc
+%%% Used for testing power_shell:export/2,3 functions. It is not possible
+%%%  to safely load and purge the power_shell_SUITE module itself when
+%%%  running tests over the module, hence the need in this one.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(power_shell_export).
+-author("maximfca@gmail.com").
+
+%% API
+-export([export_all/1]).
+
+%%--------------------------------------------------------------------
+%% IMPORTANT: THESE MUST NOT BE EXPORTED !!!
+
+local_unexported(Echo) ->
+    Echo.
+
+local_never(Echo) ->
+    Echo.
+
+%% Kitchen sink to silence compiler in a good way (without suppressing warnings)
+export_all(Arg) ->
+    local_never(local_unexported(Arg)).


### PR DESCRIPTION
Added `power_shell:export/1,2,3` functions allowing to export and hot-load
functions that weren't previously exported. Intended for testing with
Common Test, not for production debugging.